### PR TITLE
Define _info method to fix pouch-websocket-sync#2

### DIFF
--- a/methods.js
+++ b/methods.js
@@ -6,5 +6,6 @@ module.exports = [
   '_bulkDocs',
   'allDocs',
   '_id',
+  '_info',
   '_getRevisionTree',
 ];


### PR DESCRIPTION
This fixes https://github.com/pgte/pouch-websocket-sync/issues/2 by introduction of `_info` into adapter. Which is needed to replicate `remote` adapter with another one.