### PR TITLE
Add `revsDiff` and `_info` methods

### DIFF
--- a/methods.js
+++ b/methods.js
@@ -5,6 +5,8 @@ module.exports = [
   'get',
   '_bulkDocs',
   'allDocs',
+  'revsDiff',
   '_id',
   '_getRevisionTree',
+  '_info',
 ];


### PR DESCRIPTION
This fixes replication errors with pouch-websocket-sync that occur due
to missing `revsDiff` and `_info` methods.

See #1 as well as pgte/pouch-websocket-sync#2