### PR TITLE
Enable support for running with pouchdb v6...

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -23,6 +23,11 @@ function Adapter(opts, callback) {
   remote = opts.remote.recreate();
   debug('haz created remote');
 
+  /* istanbul ignore next */
+  if (! opts.originalName) {
+    opts.originalName = this.name;
+  }
+
   this._name = opts.originalName;
   this.skipDependentDatabase = true;
 


### PR DESCRIPTION
With version 6, pouchdb no longer provides `db.originalName`.
This minimal change provides it if it is absent,
enabling the code to run with pouchdb v5 or v6.